### PR TITLE
Hide Content and SEO score in publish/update box on edit Post/Page. 

### DIFF
--- a/includes/class-so-clean-up-wp-seo-settings.php
+++ b/includes/class-so-clean-up-wp-seo-settings.php
@@ -140,9 +140,9 @@ class CUWS_Settings {
 					'default'		=> 'on'
 				),
 				array(
-					'id' 			=> 'hide_trafficlight',
-					'label'			=> __( 'Trafficlight', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide seoscore traffic light in publish/update box on edit Post/Page.', 'so-clean-up-wp-seo' ),
+					'id' 			=> 'hide_seoscore',
+					'label'			=> __( 'Content and SEO score', 'so-clean-up-wp-seo' ),
+					'description'	=> __( 'Hide seoscore in publish/update box on edit Post/Page.', 'so-clean-up-wp-seo' ),
 					'type'			=> 'checkbox',
 					'default'		=> 'on'
 				),

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -219,11 +219,11 @@ class CUWS {
 		if ( !empty( $hide_addkw_button ) ) {
 			echo '.wpseo-add-keyword{display:none;}'; // @since v1.7.3 hide add-keyword-button in UI which only serves ad in overlay
 		}
-
-		// trafficlight
-		$hide_trafficlight = get_option( 'cuws_hide_trafficlight' );
-		if ( !empty( $hide_trafficlight ) ) {
-			echo '.submitbox #wpseo-score{display:none;}'; // @since v1.7.4 hide wpseo-score traffic light in publish box
+		
+		// yoast-seo-score, previously trafficlight
+		$hide_seoscore = get_option( 'cuws_hide_seoscore' );
+		if ( !empty( $hide_seoscore ) ) {
+			echo '.yoast-seo-score{display:none;}'; // @since v3.3.0 hide yoast-seo-score in publish box
 		}
 
 		// content analysis


### PR DESCRIPTION
Substitutes trafficlight since 3.3.0. Because a SEO plugin telling you that your content is poor while saving a new post, is not just nagging, but offensive too.