### PR TITLE
Rewrite of settings with fixes for PHP notices 

### DIFF
--- a/admin/class-so-clean-up-wp-seo-admin-api.php
+++ b/admin/class-so-clean-up-wp-seo-admin-api.php
@@ -20,7 +20,8 @@ class CUWS_Admin_API {
 	public function display_field( $data = array(), $post = false, $echo = true ) {
 
 		// Get plugin settings
-		$options = CUWS::instance()->get_settings_as_array();
+		$cuws    = CUWS::instance();
+		$options = get_site_option( $cuws->_token . '_settings' );
 
 		// Get field info
 		//$field = isset( $data['field'] ) ? $data['field'] : $data;
@@ -83,6 +84,9 @@ class CUWS_Admin_API {
 				break;
 
 			case 'checkbox_multi':
+				if ( empty( $data ) ) {
+					$data = array();
+				}
 				foreach ( $field['options'] as $k => $v ) {
 					$checked = false;
 					if ( in_array( $k, $data ) ) {

--- a/admin/class-so-clean-up-wp-seo-admin-api.php
+++ b/admin/class-so-clean-up-wp-seo-admin-api.php
@@ -4,6 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Class CUWS_Admin_API
+ */
 class CUWS_Admin_API {
 
 	/**
@@ -13,7 +16,7 @@ class CUWS_Admin_API {
 	 * @param object|bool $post WP_Post
 	 * @param  boolean    $echo Whether to echo the field HTML or return it
 	 *
-	 * @return void|string
+	 * @return string
 	 * @source  : //github.com/hlashbrooke/WordPress-Plugin-Template/
 	 * @since   v2.0.0
 	 */
@@ -43,7 +46,6 @@ class CUWS_Admin_API {
 		$data        = '';
 		$option_name = $field['id'];
 		if ( $post ) {
-
 			// Get saved field data
 			$option = get_post_meta( $post->ID, $field['id'], true );
 
@@ -51,9 +53,7 @@ class CUWS_Admin_API {
 			if ( isset( $option ) ) {
 				$data = $option;
 			}
-
 		} else {
-
 			// Get saved option
 			$option = $options[ $option_name ];
 
@@ -61,7 +61,6 @@ class CUWS_Admin_API {
 			if ( isset( $option ) ) {
 				$data = $option;
 			}
-
 		}
 
 		// Show default data if no option saved and default is supplied
@@ -133,7 +132,6 @@ class CUWS_Admin_API {
 		}
 
 		echo $html;
-
 	}
 
 }

--- a/includes/class-so-clean-up-wp-seo-settings.php
+++ b/includes/class-so-clean-up-wp-seo-settings.php
@@ -1,6 +1,8 @@
 <?php
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class CUWS_Settings {
 
@@ -40,7 +42,12 @@ class CUWS_Settings {
 	 */
 	public $settings = array();
 
-	public function __construct ( $parent ) {
+	/**
+	 * CUWS_Settings constructor.
+	 *
+	 * @param $parent
+	 */
+	public function __construct( $parent ) {
 		$this->parent = $parent;
 
 		$this->base = 'cuws_';
@@ -51,7 +58,7 @@ class CUWS_Settings {
 		add_action( 'init', array( $this, 'init_settings' ), 11 );
 
 		// Register plugin settings
-		add_action( 'admin_init' , array( $this, 'register_settings' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
 
 		// Add settings page to menu
 		//add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', array( $this, 'add_menu_item' ), 15 );
@@ -115,7 +122,7 @@ class CUWS_Settings {
 	 * @return void
 	 * @since   v2.0.0
 	 */
-	public function init_settings () {
+	public function init_settings() {
 		$this->settings = $this->settings_fields();
 	}
 
@@ -145,10 +152,11 @@ class CUWS_Settings {
 	 * @return array        Modified links
 	 * @since   v2.0.0
 	 */
-	public function add_settings_link ( $links ) {
+	public function add_settings_link( $links ) {
 		$settings_link = '<a href="admin.php?page=' . $this->parent->_token . '_settings">' . __( 'Settings', 'so-clean-up-wp-seo' ) . '</a>';
-  		array_unshift( $links, $settings_link );
-  		return $links;
+		array_unshift( $links, $settings_link );
+
+		return $links;
 	}
 
 	/**
@@ -159,115 +167,137 @@ class CUWS_Settings {
 	 * @modified v2.1.0 simplyfy the options to reflect changes to v3.1 of Yoast SEO plugin (temporarily removing
 	 *           non-vital notifications)
 	 */
-	private function settings_fields () {
+	private function settings_fields() {
 
 		$settings['standard'] = array(
-			'title'					=> __( 'Without further ado: Hide the bloat', 'so-clean-up-wp-seo' ),
+			'title'  => __( 'Without further ado: Hide the bloat', 'so-clean-up-wp-seo' ),
 			//'description'			=> __( 'description' ),
-			'fields'				=> array(
+			'fields' => array(
 				array(
-					'id' 			=> 'hide_ads',
-					'label'			=> __( 'Sidebar Ads', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide the cartoon-style sidebar ads on almost all settings pages of the Yoast SEO plugin.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_ads',
+					'label'       => __( 'Sidebar Ads', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide the cartoon-style sidebar ads on almost all settings pages of the Yoast SEO plugin.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_tagline_nag',
-					'label'			=> __( 'Tagline nag', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Tagline nag that shows a "Problem" in the Dashboard. Although it can be easily dismissed on a per user basis, this setting hides the "Problem" globally.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_tagline_nag',
+					'label'       => __( 'Tagline nag', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Tagline nag that shows a "Problem" in the Dashboard. Although it can be easily dismissed on a per user basis, this setting hides the "Problem" globally.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_robots_nag',
-					'label'			=> __( 'Robots nag', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide robots nag that shows a "Problem" in the Dashboard. Although it can be easily dismissed on a per user basis, this setting hides the "Problem" globally.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_robots_nag',
+					'label'       => __( 'Robots nag', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide robots nag that shows a "Problem" in the Dashboard. Although it can be easily dismissed on a per user basis, this setting hides the "Problem" globally.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_upsell_notice',
-					'label'			=> __( 'Upsell Notice', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide the Upsell Notice in the Notifications box that shows in the Yoast SEO Dashboard. Although it can be easily dismissed on a per user basis, this setting hides the Notice globally.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_upsell_notice',
+					'label'       => __( 'Upsell Notice', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide the Upsell Notice in the Notifications box that shows in the Yoast SEO Dashboard. Although it can be easily dismissed on a per user basis, this setting hides the Notice globally.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_dashboard_problems_notifications',
-					'label'			=> __( 'Problems/Notifications', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide Problems/Notifications boxes from Yoast Dashboard. Although they can be easily dismissed on a per user basis, this setting hides the box(es) globally.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'radio',
-					'options'		=> array( 'both' => __( 'Hide both Problems/Notifications boxes', 'so-clean-up-wp-seo' ), 'problems' => __( 'Only hide Problems box', 'so-clean-up-wp-seo' ), 'notifications' => __( 'Only hide Notifications box', 'so-clean-up-wp-seo' ), 'none' => __( 'None', 'so-clean-up-wp-seo' ) ),
-					'default'		=> 'none'
+					'id'          => 'hide_dashboard_problems_notifications',
+					'label'       => __( 'Problems/Notifications', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide Problems/Notifications boxes from Yoast Dashboard. Although they can be easily dismissed on a per user basis, this setting hides the box(es) globally.', 'so-clean-up-wp-seo' ),
+					'type'        => 'radio',
+					'options'     => array(
+						'both'          => __( 'Hide both Problems/Notifications boxes', 'so-clean-up-wp-seo' ),
+						'problems'      => __( 'Only hide Problems box', 'so-clean-up-wp-seo' ),
+						'notifications' => __( 'Only hide Notifications box', 'so-clean-up-wp-seo' ),
+						'none'          => __( 'None', 'so-clean-up-wp-seo' ),
+					),
+					'default'     => 'none',
 				),
 				array(
-					'id' 			=> 'hide_imgwarning_nag',
-					'label'			=> __( 'Featured image nag', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide image warning nag that shows in edit Post/Page screen when featured image is smaller than 200x200 pixels.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_imgwarning_nag',
+					'label'       => __( 'Featured image nag', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide image warning nag that shows in edit Post/Page screen when featured image is smaller than 200x200 pixels.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_addkw_button',
-					'label'			=> __( 'Add keyword button', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide add keyword button that shows in edit Post/Page and only serves to show an ad for the premium version.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_addkw_button',
+					'label'       => __( 'Add keyword button', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide add keyword button that shows in edit Post/Page and only serves to show an ad for the premium version.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_wpseoanalysis',
-					'label'			=> __( 'Content analysis', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide content analysis that adds colored balls to the edit Post/Page screens as well as Readability tab that contains the analysis.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_wpseoanalysis',
+					'label'       => __( 'Content analysis', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide content analysis that adds colored balls to the edit Post/Page screens as well as Readability tab that contains the analysis.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_issue_counter',
-					'label'			=> __( 'Issue Counter', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide issue counter from adminbar and sidebar.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_issue_counter',
+					'label'       => __( 'Issue Counter', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide issue counter from adminbar and sidebar.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_gopremium_star',
-					'label'			=> __( 'Go Premium', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hides red star of "Go Premium" submenu as well as of metabox in edit Post/Page screens.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
+					'id'          => 'hide_gopremium_star',
+					'label'       => __( 'Go Premium', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hides red star of "Go Premium" submenu as well as of metabox in edit Post/Page screens.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
 				),
 				array(
-					'id' 			=> 'hide_content_keyword_score',
-					'label'			=> __( 'Content (Readability) / Keyword (SEO) Score', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Hide Content (Readability)/Keyword (SEO) Score in publish/update box on edit Post/Page.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'radio',
-					'options'		=> array( 'both' => __( 'Hide both Content (Readability) and Keyword (SEO) Score', 'so-clean-up-wp-seo' ), 'keyword_score' => __( 'Only hide Keyword (SEO) Score', 'so-clean-up-wp-seo' ), 'content_score' => __( 'Only hide Content (Readability) Score', 'so-clean-up-wp-seo' ), 'none' => __( 'None', 'so-clean-up-wp-seo' ) ),
-					'default'		=> 'both'
+					'id'          => 'hide_content_keyword_score',
+					'label'       => __( 'Content (Readability) / Keyword (SEO) Score', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Hide Content (Readability)/Keyword (SEO) Score in publish/update box on edit Post/Page.', 'so-clean-up-wp-seo' ),
+					'type'        => 'radio',
+					'options'     => array(
+						'both'          => __( 'Hide both Content (Readability) and Keyword (SEO) Score', 'so-clean-up-wp-seo' ),
+						'keyword_score' => __( 'Only hide Keyword (SEO) Score', 'so-clean-up-wp-seo' ),
+						'content_score' => __( 'Only hide Content (Readability) Score', 'so-clean-up-wp-seo' ),
+						'none'          => __( 'None', 'so-clean-up-wp-seo' ),
+					),
+					'default'     => 'both',
 				),
 				array(
-					'id' 			=> 'hide_helpcenter',
-					'label'			=> __( 'Help center', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'The Yoast SEO plugin comes with a help center (since Yoast SEO 3.2) that shows introduction videos and (of course) an ad for the premium version of the plugin; select here what to hide (if anything).', 'so-clean-up-wp-seo' ),
-					'type'			=> 'radio',
-					'options'		=> array( 'ad' => __( 'Only hide ad for premium version', 'so-clean-up-wp-seo' ), 'helpcenter' => __( 'Hide the entire help center', 'so-clean-up-wp-seo' ), 'none' => __( 'None', 'so-clean-up-wp-seo' ) ),
-					'default'		=> 'ad'
+					'id'          => 'hide_helpcenter',
+					'label'       => __( 'Help center', 'so-clean-up-wp-seo' ),
+					'description' => __( 'The Yoast SEO plugin comes with a help center (since Yoast SEO 3.2) that shows introduction videos and (of course) an ad for the premium version of the plugin; select here what to hide (if anything).', 'so-clean-up-wp-seo' ),
+					'type'        => 'radio',
+					'options'     => array(
+						'ad'         => __( 'Only hide ad for premium version', 'so-clean-up-wp-seo' ),
+						'helpcenter' => __( 'Hide the entire help center', 'so-clean-up-wp-seo' ),
+						'none'       => __( 'None', 'so-clean-up-wp-seo' ),
+					),
+					'default'     => 'ad',
 				),
 				array(
-					'id' 			=> 'hide_admincolumns',
-					'label'			=> __( 'Admin columns', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'The Yoast SEO plugin adds 5(!) admin columns on the Posts/Pages screen and the SEO Score?Readability admin columns to taxonomies (since Yoast SEO 3.1), choose here which ones to hide. It is possible to select multiple columns to hide and <strong>ticking minimum one box is required</strong>.<br> Although they can be easily hidden on a per user basis, this setting hides the column(s) globally.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox_multi',
-					'options'		=> array( 'all' => __( 'Hide all columns', 'so-clean-up-wp-seo' ), 'seoscore' => __( 'Hide SEO score column', 'so-clean-up-wp-seo' ), 'readability' => __( 'Hide Readability score column', 'so-clean-up-wp-seo' ), 'title' => __( 'Hide title column', 'so-clean-up-wp-seo' ), 'metadescr' => __( 'Hide meta description column', 'so-clean-up-wp-seo' ), 'focuskw' => __( 'Hide focus keyword column', 'so-clean-up-wp-seo' ), 'none' => __( 'Show all columns', 'so-clean-up-wp-seo' ) ),
-					'default'		=> array( 'seoscore', 'readability', 'title', 'metadescr'  )
+					'id'          => 'hide_admincolumns',
+					'label'       => __( 'Admin columns', 'so-clean-up-wp-seo' ),
+					'description' => __( 'The Yoast SEO plugin adds 5(!) admin columns on the Posts/Pages screen and the SEO Score?Readability admin columns to taxonomies (since Yoast SEO 3.1), choose here which ones to hide. It is possible to select multiple columns to hide and <strong>ticking minimum one box is required</strong>.<br> Although they can be easily hidden on a per user basis, this setting hides the column(s) globally.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox_multi',
+					'options'     => array(
+						'all'         => __( 'Hide all columns', 'so-clean-up-wp-seo' ),
+						'seoscore'    => __( 'Hide SEO score column', 'so-clean-up-wp-seo' ),
+						'readability' => __( 'Hide Readability score column', 'so-clean-up-wp-seo' ),
+						'title'       => __( 'Hide title column', 'so-clean-up-wp-seo' ),
+						'metadescr'   => __( 'Hide meta description column', 'so-clean-up-wp-seo' ),
+						'focuskw'     => __( 'Hide focus keyword column', 'so-clean-up-wp-seo' ),
+						'none'        => __( 'Show all columns', 'so-clean-up-wp-seo' ),
+					),
+					'default'     => array( 'seoscore', 'readability', 'title', 'metadescr' ),
 				),
 				array(
-					'id' 			=> 'remove_dbwidget',
-					'label'			=> __( 'Dashboard widget', 'so-clean-up-wp-seo' ),
-					'description'	=> __( 'Remove the Yoast SEO widget from the WordPress Dashboard.', 'so-clean-up-wp-seo' ),
-					'type'			=> 'checkbox',
-					'default'		=> 'on'
-				)
-			)
+					'id'          => 'remove_dbwidget',
+					'label'       => __( 'Dashboard widget', 'so-clean-up-wp-seo' ),
+					'description' => __( 'Remove the Yoast SEO widget from the WordPress Dashboard.', 'so-clean-up-wp-seo' ),
+					'type'        => 'checkbox',
+					'default'     => 'on',
+				),
+			),
 		);
 
 		$settings = apply_filters( $this->parent->_token . '_settings_fields', $settings );
@@ -281,7 +311,7 @@ class CUWS_Settings {
 	 * @return void
 	 * @since   v2.0.0
 	 */
-	public function register_settings () {
+	public function register_settings() {
 		if ( is_array( $this->settings ) ) {
 
 			// Check posted/selected tab
@@ -296,20 +326,44 @@ class CUWS_Settings {
 
 			foreach ( $this->settings as $section => $data ) {
 
-				if ( $current_section && $current_section != $section ) continue;
+				if ( $current_section && $current_section != $section ) {
+					continue;
+				}
 
 				register_setting( $this->parent->_token . '_settings', 'settings' );
 
 				// Add section to page
-				add_settings_section( $section, $data['title'], array( $this, 'settings_section' ), $this->parent->_token . '_settings' );
+				add_settings_section( $section,
+					$data['title'],
+					array(
+						$this,
+						'settings_section',
+					),
+					$this->parent->_token . '_settings'
+				);
 
 				foreach ( $data['fields'] as $field ) {
 
 					// Add field to page
-					add_settings_field( $field['id'], $field['label'], array( $this->parent->admin, 'display_field' ), $this->parent->_token . '_settings', $section, array( 'field' => $field, 'prefix' => $this->base ) );
+					add_settings_field(
+						$field['id'],
+						$field['label'],
+						array(
+							$this->parent->admin,
+							'display_field',
+						),
+						$this->parent->_token . '_settings',
+						$section,
+						array(
+							'field'  => $field,
+							'prefix' => $this->base,
+						)
+					);
 				}
 
-				if ( ! $current_section ) break;
+				if ( ! $current_section ) {
+					break;
+				}
 			}
 		}
 		if ( isset( $_POST['action'] ) && 'update' === $_POST['action'] ) {
@@ -333,17 +387,17 @@ class CUWS_Settings {
 	 * @return void
 	 * @since   v2.0.0
 	 */
-	public function settings_page () {
+	public function settings_page() {
 
 		// Build page HTML
 		$html = '<div class="wrap" id="' . $this->parent->_token . '_settings">' . "\n";
-			$html .= '<h2>' . esc_attr( __( 'SO Hide SEO Bloat Settings' , 'so-clean-up-wp-seo' ) ) . '</h2>' . "\n";
+		$html .= '<h2>' . esc_attr( __( 'SO Hide SEO Bloat Settings', 'so-clean-up-wp-seo' ) ) . '</h2>' . "\n";
 
-			$html .= '<p>' . esc_attr( __( 'With version 2.0.0 we have added this settings page, so you can adjust things here and there to your liking.', 'so-clean-up-wp-seo' ) ) . '</p>' .  "\n";
+		$html .= '<p>' . esc_attr( __( 'With version 2.0.0 we have added this settings page, so you can adjust things here and there to your liking.', 'so-clean-up-wp-seo' ) ) . '</p>' . "\n";
 
-			$html .= '<p>' . esc_attr( __( 'The default setting, when you activate the plugin, is that almost all boxes have been ticked; why else would you install our plugin?', 'so-clean-up-wp-seo' ) ) . '</p>' .  "\n";
+		$html .= '<p>' . esc_attr( __( 'The default setting, when you activate the plugin, is that almost all boxes have been ticked; why else would you install our plugin?', 'so-clean-up-wp-seo' ) ) . '</p>' . "\n";
 
-			$html .= '<p>' . esc_attr( __( 'If you ever want to remove the SO Hide SEO Bloat plugin, then you can rest assured that it cleans up after itself:', 'so-clean-up-wp-seo' ) ) . '<br />' . esc_attr( __( 'upon deletion it removes all options automatically.', 'so-clean-up-wp-seo' ) ) . '</p>' .  "\n";
+		$html .= '<p>' . esc_attr( __( 'If you ever want to remove the SO Hide SEO Bloat plugin, then you can rest assured that it cleans up after itself:', 'so-clean-up-wp-seo' ) ) . '<br />' . esc_attr( __( 'upon deletion it removes all options automatically.', 'so-clean-up-wp-seo' ) ) . '</p>' . "\n";
 
 		//$action = is_network_admin() ? 'edit.php?action=' . $this->parent->_token . '_settings' : 'options.php';
 		if ( is_network_admin() ) {
@@ -352,58 +406,58 @@ class CUWS_Settings {
 			$action = 'options.php';
 		}
 
-			$html .= '<form method="post" action="' . $action . '" enctype="multipart/form-data">' . "\n";
+		$html .= '<form method="post" action="' . $action . '" enctype="multipart/form-data">' . "\n";
 
-				// Get settings fields
-				ob_start();
-				settings_fields( $this->parent->_token . '_settings' );
-				do_settings_sections( $this->parent->_token . '_settings' );
-				$html .= ob_get_clean();
+		// Get settings fields
+		ob_start();
+		settings_fields( $this->parent->_token . '_settings' );
+		do_settings_sections( $this->parent->_token . '_settings' );
+		$html .= ob_get_clean();
 
-				$html .= '<p class="submit">' . "\n";
+		$html .= '<p class="submit">' . "\n";
 
-					$html .= '<input name="Submit" type="submit" class="button-primary" value="' . esc_attr( __( 'Save Settings' , 'so-clean-up-wp-seo' ) ) . '" />' . "\n";
-				$html .= '</p>' . "\n";
-			$html .= '</form>' . "\n";
+		$html .= '<input name="Submit" type="submit" class="button-primary" value="' . esc_attr( __( 'Save Settings', 'so-clean-up-wp-seo' ) ) . '" />' . "\n";
+		$html .= '</p>' . "\n";
+		$html .= '</form>' . "\n";
 
 
-			// see //codex.wordpress.org/I18n_for_WordPress_Developers#HTML for instructions on i18n of $html
-			$rateurl = 'https://wordpress.org/support/view/plugin-reviews/so-clean-up-wp-seo?rate=5#postform';
-			$html .= '<p class="rate-this-plugin">' . sprintf( wp_kses( __( 'If you have found this plugin at all useful, please give it a favourable rating in the <a href="%s" title="Rate this plugin!">WordPress Plugin Repository</a>.', 'so-clean-up-wp-seo' ), array(  'a' => array( 'href' => array() ) ) ), esc_url( $rateurl ) ) . '</p>' . "\n";
+		// see //codex.wordpress.org/I18n_for_WordPress_Developers#HTML for instructions on i18n of $html
+		$rateurl = 'https://wordpress.org/support/view/plugin-reviews/so-clean-up-wp-seo?rate=5#postform';
+		$html    .= '<p class="rate-this-plugin">' . sprintf( wp_kses( __( 'If you have found this plugin at all useful, please give it a favourable rating in the <a href="%s" title="Rate this plugin!">WordPress Plugin Repository</a>.', 'so-clean-up-wp-seo' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( $rateurl ) ) . '</p>' . "\n";
 
-			$translateurl = 'https://translate.wordpress.org/projects/wp-plugins/so-clean-up-wp-seo';
-			$html .= '<p class="translate">' . sprintf( wp_kses( __( 'You can also help a great deal by <a href="%s" title="translate the plugin into your own language">translating the plugin</a> into your own language.', 'so-clean-up-wp-seo' ), array(  'a' => array( 'href' => array() ) ) ), esc_url( $translateurl ) ) . '</p>' . "\n";
+		$translateurl = 'https://translate.wordpress.org/projects/wp-plugins/so-clean-up-wp-seo';
+		$html         .= '<p class="translate">' . sprintf( wp_kses( __( 'You can also help a great deal by <a href="%s" title="translate the plugin into your own language">translating the plugin</a> into your own language.', 'so-clean-up-wp-seo' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( $translateurl ) ) . '</p>' . "\n";
 
-			$supporturl = 'https://github.com/senlin/so-clean-up-wp-seo/issues';
-			$html .= '<p class="support">' . sprintf( wp_kses( __( 'If you have an issue with this plugin or want to leave a feature request, please note that we give <a href="%s" title="Support or Feature Requests via Github">support via Github</a> only.', 'so-clean-up-wp-seo' ), array(  'a' => array( 'href' => array() ) ) ), esc_url( $supporturl ) ) . '</p>' . "\n";
+		$supporturl = 'https://github.com/senlin/so-clean-up-wp-seo/issues';
+		$html       .= '<p class="support">' . sprintf( wp_kses( __( 'If you have an issue with this plugin or want to leave a feature request, please note that we give <a href="%s" title="Support or Feature Requests via Github">support via Github</a> only.', 'so-clean-up-wp-seo' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( $supporturl ) ) . '</p>' . "\n";
 
-			$html .= '<div class="author postbox">' . "\n";
+		$html .= '<div class="author postbox">' . "\n";
 
-			$html .= '<h3 class="hndle"><span>' . esc_attr( __( 'About the Author', 'so-clean-up-wp-seo' ) ) . '</span></h3>' . "\n";
+		$html .= '<h3 class="hndle"><span>' . esc_attr( __( 'About the Author', 'so-clean-up-wp-seo' ) ) . '</span></h3>' . "\n";
 
-			$html .= '<div class="inside">' . "\n";
-			$html .= '<div class="top">' . "\n";
+		$html .= '<div class="inside">' . "\n";
+		$html .= '<div class="top">' . "\n";
 
-			$html .= '<img class="author-image" src="' . esc_url( plugins_url( 'so-clean-up-wp-seo/images/pietbos-80x80.jpg' ) ) . '" alt="plugin author Piet Bos" width="80" height="80" />' . "\n";
+		$html .= '<img class="author-image" src="' . esc_url( plugins_url( 'so-clean-up-wp-seo/images/pietbos-80x80.jpg' ) ) . '" alt="plugin author Piet Bos" width="80" height="80" />' . "\n";
 
-			$sowpurl = 'https://so-wp.com/plugins/';
-			$html .= '<p>' . sprintf( wp_kses( __( 'Hi, my name is Piet Bos, I hope you like this plugin! Please check out any of my other plugins on <a href="%s" title="SO WP Plugins">SO WP Plugins</a>. You can find out more information about me via the following links:', 'so-clean-up-wp-seo' ), array(  'a' => array( 'href' => array() ) ) ), esc_url( $sowpurl ) ) . '</p>' . "\n";
+		$sowpurl = 'https://so-wp.com/plugins/';
+		$html    .= '<p>' . sprintf( wp_kses( __( 'Hi, my name is Piet Bos, I hope you like this plugin! Please check out any of my other plugins on <a href="%s" title="SO WP Plugins">SO WP Plugins</a>. You can find out more information about me via the following links:', 'so-clean-up-wp-seo' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( $sowpurl ) ) . '</p>' . "\n";
 
-			$html .= '</div>' . "\n"; // end .top
+		$html .= '</div>' . "\n"; // end .top
 
-			$html .= '<ul>' . "\n";
-			$html .= '<li><a href="https://bohanintl.com/" target="_blank" title="BHI Consulting">' . esc_attr( __('BHI Consulting', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
-			$html .= '<li><a href="https://www.linkedin.com/in/pietbos" target="_blank" title="LinkedIn profile">' . esc_attr( __( 'LinkedIn', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
-			$html .= '<li><a href="https://so-wp.com/" target="_blank" title="SO WP">' . esc_attr( __('SO WP', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
-			$html .= '<li><a href="https://github.com/senlin" title="on Github">' . esc_attr( __( 'Github', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
-			$html .= '<li><a href="https://profiles.wordpress.org/senlin/" title="on WordPress.org">' . esc_attr( __( 'WordPress.org Profile', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
-			$html .= '</ul>' . "\n";
+		$html .= '<ul>' . "\n";
+		$html .= '<li><a href="https://bohanintl.com/" target="_blank" title="BHI Consulting">' . esc_attr( __( 'BHI Consulting', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
+		$html .= '<li><a href="https://www.linkedin.com/in/pietbos" target="_blank" title="LinkedIn profile">' . esc_attr( __( 'LinkedIn', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
+		$html .= '<li><a href="https://so-wp.com/" target="_blank" title="SO WP">' . esc_attr( __( 'SO WP', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
+		$html .= '<li><a href="https://github.com/senlin" title="on Github">' . esc_attr( __( 'Github', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
+		$html .= '<li><a href="https://profiles.wordpress.org/senlin/" title="on WordPress.org">' . esc_attr( __( 'WordPress.org Profile', 'so-clean-up-wp-seo' ) ) . '</a></li>' . "\n";
+		$html .= '</ul>' . "\n";
 
-			$html .= '</div>' . "\n"; // end .inside
+		$html .= '</div>' . "\n"; // end .inside
 
-			$html .= '</div>' . "\n"; // end .postbox
+		$html .= '</div>' . "\n"; // end .postbox
 
-			$html .= '</div>' . "\n";
+		$html .= '</div>' . "\n";
 
 		echo $html;
 	}
@@ -434,7 +488,7 @@ class CUWS_Settings {
 	 *
 	 * @since v2.0.0
 	 */
-	public function __clone () {
+	public function __clone() {
 		_doing_it_wrong( __FUNCTION__, __( 'Access denied' ), $this->parent->_version );
 	} // End __clone()
 
@@ -443,7 +497,7 @@ class CUWS_Settings {
 	 *
 	 * @since v2.0.0
 	 */
-	public function __wakeup () {
+	public function __wakeup() {
 		_doing_it_wrong( __FUNCTION__, __( 'Access denied' ), $this->parent->_version );
 	} // End __wakeup()
 

--- a/includes/class-so-clean-up-wp-seo-settings.php
+++ b/includes/class-so-clean-up-wp-seo-settings.php
@@ -125,12 +125,13 @@ class CUWS_Settings {
 	 * @return void
 	 * @since   v2.0.0
 	 */
-	public function add_menu_item () {
+	public function add_menu_item() {
+		$capability = is_multisite() ? 'manage_network' : 'manage_options';
 		add_submenu_page(
 			'wpseo_dashboard',
 			__( 'SO Hide SEO Bloat Settings', 'so-clean-up-wp-seo' ),
 			__( 'Hide Bloat', 'so-clean-up-wp-seo' ),
-			'manage_options',
+			$capability,
 			$this->parent->_token . '_settings',
 			array( $this, 'settings_page' )
 		);

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -127,7 +127,14 @@ class CUWS {
 			$this->admin = new CUWS_Admin_API();
 		}
 
-		$this->options = $this->get_settings_as_array();
+		$this->options = get_site_option( $this->_token . '_settings' );
+
+		// Make sure options have been populated if messed up from new settings
+		// Simpler than requiring deactivation/activation of plugin.
+		if ( ! $this->options ) {
+			$this->install();
+			$this->options = get_site_option( $this->_token . '_settings' );
+		}
 
 	} // End __construct ()
 
@@ -244,6 +251,9 @@ class CUWS {
 		// @modified 2.6.1 revert radio to checkboxes and removing the options for focus keyword, title and meta-description
 		
 		// all columns
+		if ( ! is_array( $this->options['hide_admincolumns'] ) ) {
+			$this->options['hide_admincolumns'] = array( 'none' );
+		}
 		if ( in_array( 'all', $this->options['hide_admincolumns'] ) ) {
 			echo '.column-wpseo-score,.column-wpseo_score,.column-wpseo-score-readability,.column-wpseo_score_readability,.column-wpseo-title,.column-wpseo-metadesc,.column-wpseo-focuskw{display:none;}'; // @since v2.0.0 remove seo columns one by one
 		}
@@ -366,61 +376,47 @@ class CUWS {
 	} // End _log_version_number ()
 
 	/**
+	 * Array containing the default values.
+	 * Use `array_keys()` to return the key names.
+	 *
+	 * @return array
+	 */
+	public function get_defaults() {
+		$defaults = array(
+			'hide_ads'                              => 'on',
+			'hide_tagline_nag'                      => 'on',
+			'hide_robots_nag'                       => 'on',
+			'hide_upsell_notice'                    => 'on',
+			'hide_dashboard_problems_notifications' => 'none',
+			'hide_imgwarning_nag'                   => 'on',
+			'hide_addkw_button'                     => 'on',
+			'hide_trafficlight'                     => 'on',
+			'hide_wpseoanalysis'                    => 'on',
+			'hide_issue_counter'                    => 'on',
+			'hide_gopremium_star'                   => 'on',
+			'hide_content_keyword_score'            => 'both',
+			'hide_helpcenter'                       => 'ad',
+			'hide_admincolumns'                     => array(
+				'seoscore',
+				'readibility',
+				'title',
+				'metadescr',
+			),
+			'remove_dbwidget'                       => 'on',
+		);
+
+		return $defaults;
+	}
+
+	/**
 	 * Set default values on activation.
 	 *
 	 * @access private
 	 * @return void
 	 */
 	private function _set_defaults() {
-		update_site_option( 'cuws_hide_ads', 'on' );
-		update_site_option( 'cuws_hide_tagline_nag', 'on' );
-		update_site_option( 'cuws_hide_robots_nag', 'on' );
-		update_site_option( 'cuws_hide_upsell_notice', 'on' );
-		update_site_option( 'hide_dashboard_problems_notifications', 'none' );
-		update_site_option( 'cuws_hide_imgwarning_nag', 'on' );
-		update_site_option( 'cuws_hide_addkw_button', 'on' );
-		update_site_option( 'cuws_hide_trafficlight', 'on' );
-		update_site_option( 'cuws_hide_issue_counter', 'on' );
-		update_site_option( 'cuws_hide_gopremium_star', 'on' );
-		update_site_option( 'cuws_hide_wpseoanalysis', 'on' );
-		update_site_option( 'cuws_hide_content_keyword_score', 'both' );
-		update_site_option( 'cuws_hide_helpcenter', 'ad' );
-		update_site_option( 'hide_admincolumns', array( 'seoscore', 'readibility', 'title', 'metadescr' ) );
-		update_site_option( 'cuws_remove_dbwidget', 'on' );
+		$defaults = $this->get_defaults();
+		update_site_option( $this->_token . '_settings', $defaults );
 	} // End _set_defaults ()
-
-	/**
-	 * Get plugin settings as an array.
-	 *
-	 * @access public
-	 * @return array
-	 */
-	public function get_settings_as_array() {
-		$settings = array();
-		$options  = array(
-			'hide_ads',
-			'hide_tagline_nag',
-			'hide_robots_nag',
-			'hide_upsell_notice',
-			'hide_dashboard_problems_notifications',
-			'hide_imgwarning_nag',
-			'hide_addkw_button',
-			'hide_trafficlight',
-			'hide_wpseoanalysis',
-			'hide_issue_counter',
-			'hide_gopremium_star',
-			'hide_content_keyword_score',
-			'hide_helpcenter',
-			'hide_admincolumns',
-			'remove_dbwidget',
-		);
-
-		foreach ( $options as $option ) {
-			$settings[ $option ] = get_site_option( $this->_token . '_' . $option );
-		}
-		$settings['version'] = $this->_version;
-
-		return $settings;
-	}
 
 }

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -1,7 +1,12 @@
 <?php
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
+/**
+ * Class CUWS
+ */
 class CUWS {
 
 	/**
@@ -93,16 +98,14 @@ class CUWS {
 	 *
 	 * @param string $file
 	 * @param string $version Version number.
-	 *
-	 * @return  void
 	 */
-	public function __construct ( $file = '', $version = '2.6.1' ) {
+	public function __construct( $file = '', $version = '2.6.1' ) {
 		$this->_version = $version;
-		$this->_token = 'cuws';
+		$this->_token   = 'cuws';
 
 		// Load plugin environment variables
-		$this->file = $file;
-		$this->dir = dirname( $this->file );
+		$this->file       = $file;
+		$this->dir        = dirname( $this->file );
 		$this->assets_dir = trailingslashit( $this->dir ) . 'css';
 		$this->assets_url = esc_url( trailingslashit( plugins_url( '/css/', $this->file ) ) );
 
@@ -145,7 +148,8 @@ class CUWS {
 	 */
 
 	/**
-	 * Since Yoast SEO 3.6 it is possible to disable the adminbar menu within Dashboard > Features, therefore this setting has become redundant
+	 * Since Yoast SEO 3.6 it is possible to disable the adminbar menu within Dashboard > Features, therefore this
+	 * setting has become redundant
 	 *
 	 * @since v2.5.0
 	 */
@@ -169,9 +173,9 @@ class CUWS {
 	 * CSS needed to hide the various options ticked with checkboxes
 	 *
 	 * @since    v2.0.0
-	 * @modified v2.1.0 remove options for nags that have been temporarily disabled in v3.1 of Yoast SEO plugin
+	 * @modified v2.1.0 remove options for nags that have been temporarily
+	 * disabled in v3.1 of Yoast SEO plugin
 	 */
-	// CSS needed to hide the various options ticked with checkboxes
 	public function so_cuws_hide_visibility_css() {
 
 		echo '<style media="screen" id="so-hide-seo-bloat" type="text/css">';
@@ -243,13 +247,18 @@ class CUWS {
 			echo '.yoast-seo-score.content-score{display:none;}'; // @since v2.3.0 hide both Keyword and Content Score from edit Post/Page screens
 		}
 
-		// admin columns
-		// @since v2.0.0 remove seo columns one by one
-		// @modified 2.0.2 add empty array as default to avoid warnings form subsequent in_array checks - credits [Ronny Myhre Njaastad](https://github.com/ronnymn)
-		// @modified 2.1 simplyfy the CSS rules and add the rule to hide the seo-score column on taxonomies (added to v3.1 of Yoast SEO plugin)
-		// @modified 2.6.0 only 2 columns left change from checkboxes to radio
-		// @modified 2.6.1 revert radio to checkboxes and removing the options for focus keyword, title and meta-description
-		
+		/*
+		 * admin columns
+		 * @since v2.0.0 remove seo columns one by one
+		 * @modified 2.0.2 add empty array as default to avoid warnings form subsequent
+		 *  in_array checks - credits [Ronny Myhre Njaastad](https://github.com/ronnymn)
+		 * @modified 2.1 simplify the CSS rules and add the rule to hide the seo-score
+		 *  column on taxonomies (added to v3.1 of Yoast SEO plugin)
+		 * @modified 2.6.0 only 2 columns left change from checkboxes to radio
+		 * @modified 2.6.1 revert radio to checkboxes and removing the options
+		 *  for focus keyword, title and meta-description
+		 */
+
 		// all columns
 		if ( ! is_array( $this->options['hide_admincolumns'] ) ) {
 			$this->options['hide_admincolumns'] = array( 'none' );
@@ -261,6 +270,7 @@ class CUWS {
 		if ( in_array( 'seoscore', $this->options['hide_admincolumns'] ) ) {
 			echo '.column-wpseo-score,.column-wpseo_score{display:none;}'; // @since v2.0.0 remove seo columns one by one
 		}
+		// readability column
 		if ( in_array( 'readability', $this->options['hide_admincolumns'] ) ) {
 			echo '.column-wpseo-score-readability,.column-wpseo_score_readability{display:none;}'; // @since v2.6.0 remove added readibility column
 		}
@@ -296,7 +306,7 @@ class CUWS {
 	 * @since   v2.0.0
 	 * @return  void
 	 */
-	public function admin_enqueue_styles ( $hook = '' ) {
+	public function admin_enqueue_styles( $hook = '' ) {
 		wp_register_style( $this->_token . '-admin', esc_url( $this->assets_url ) . 'admin.css', array(), $this->_version );
 		wp_enqueue_style( $this->_token . '-admin' );
 	} // End admin_enqueue_styles ()
@@ -307,8 +317,6 @@ class CUWS {
 	 * @since v1.0.0
 	 */
 	function i18n() {
-
-		/* Load the translation of the plugin. */
 		load_plugin_textdomain( 'so-clean-up-wp-seo', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 	}
 
@@ -339,7 +347,7 @@ class CUWS {
 	 *
 	 * @since v2.0.0
 	 */
-	public function __clone () {
+	public function __clone() {
 		_doing_it_wrong( __FUNCTION__, __( 'No Access' ), $this->_version );
 	} // End __clone ()
 
@@ -348,7 +356,7 @@ class CUWS {
 	 *
 	 * @since v2.0.0
 	 */
-	public function __wakeup () {
+	public function __wakeup() {
 		_doing_it_wrong( __FUNCTION__, __( 'No Access' ), $this->_version );
 	} // End __wakeup ()
 
@@ -359,7 +367,7 @@ class CUWS {
 	 * @since   v2.0.0
 	 * @return  void
 	 */
-	public function install () {
+	public function install() {
 		$this->_log_version_number();
 		$this->_set_defaults();
 	} // End install ()

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * 
+ *
  * This file runs when the plugin in uninstalled (deleted).
  * This will not run when the plugin is deactivated.
  * Ideally you will add all your clean-up scripts here
@@ -22,6 +22,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
  * @since v2.0.0
  */
 global $wpdb;
-$wpdb->query( "DELETE FROM `{$wpdb->prefix}options` WHERE `option_name` LIKE '%cuws_%'" );
-
-
+$table         = is_multisite() ? $wpdb->base_prefix . 'sitemeta' : $wpdb->base_prefix . 'options';
+$column        = is_multisite() ? 'meta_key' : 'option_name';
+$delete_string = 'DELETE FROM ' . $table . ' WHERE ' . $column . ' LIKE %s LIMIT 1000';
+$wpdb->query( $wpdb->prepare( $delete_string, array( '%cuws_%' ) ) );


### PR DESCRIPTION
I didn't  update `readme.txt` so changes and new version number will be needed.

I don't think anything should break with the new settings format.

I'm using the WordPress Coding Standards setting in PhpStorm which is where the spacing changes come from.

Should fix #24 

Let me know if you have questions.