### PR TITLE
create _get_options() that returns site options

### DIFF
--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -132,15 +132,7 @@ class CUWS {
 			$this->admin = new CUWS_Admin_API();
 		}
 
-		$this->options = get_site_option( $this->_token . '_settings' );
-
-		// Make sure options have been populated if messed up from new settings
-		// Simpler than requiring deactivation/activation of plugin.
-		if ( ! $this->options ) {
-			$this->install();
-			$this->options = get_site_option( $this->_token . '_settings' );
-		}
-
+		$this->options = $this->_get_options();
 	} // End __construct ()
 
 	/**
@@ -467,5 +459,24 @@ class CUWS {
 		$defaults = $this->get_defaults();
 		update_site_option( $this->_token . '_settings', $defaults );
 	} // End _set_defaults ()
+
+	/**
+	 * Get plugin options.
+	 * Add new default options if missing from saved options.
+	 *
+	 * @return array $options Plugin options.
+	 */
+	private function _get_options() {
+		$options  = get_site_option( $this->_token . '_settings', array() );
+		$defaults = $this->get_defaults();
+		$diff     = array_diff_key( $defaults, $options );
+
+		if ( ! empty( $diff ) ) {
+			$options = array_merge( $options, $diff );
+			update_site_option( $this->_token . '_settings', $options );
+		}
+
+		return $options;
+	}
 
 }


### PR DESCRIPTION
Adds missing default options
Fixes https://github.com/senlin/so-clean-up-wp-seo/issues/44
