### PR TITLE
commit v3.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![plugin version](https://img.shields.io/wordpress/plugin/v/so-clean-up-wp-seo.svg)](https://wordpress.org/plugins/so-clean-up-wp-seo)
 
-###### Last updated on October 29, 2018
-###### Development version 3.9.1
+###### Last updated on November 19, 2018
+###### Development version 3.9.2
 ###### requires at least WordPress 4.7.2
 ###### tested up to WordPress 5.0
 ###### Author: [Pieter Bos](https://github.com/senlin)
@@ -38,7 +38,7 @@ The default settings of the current release are as follows:
 * hide the Premium Upsell Admin Block that shows in the entire Yoast SEO backend
 * hides "Premium" submenu in its entirety
 * hides "Go Premium" metabox on edit Post/Page screens
-* **NEW:** hides Post/Page/Taxonomy Deletion Premium Ad
+* hides Post/Page/Taxonomy Deletion Premium Ad
 * hide Problems box from Yoast SEO Dashboard
 * hide Notifications box from Yoast SEO Dashboard
 * hide image warning nag that shows in edit Post/Page screen when featured image is smaller than 200x200 pixels
@@ -111,6 +111,11 @@ We welcome your contributions very much! PR's will be considered and of course b
 
 
 ## Changelog
+
+### 3.9.2
+
+* release date November 19, 2018
+* fix issue where Go Premium metabox option makes snippet preview box blank (https://wordpress.org/support/topic/go-premium-metabox-option-makes-snippet-preview-box-blank/); thanks for reporting @pxlar8
 
 ### 3.9.1
 

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -99,7 +99,7 @@ class CUWS {
 	 * @param string $file
 	 * @param string $version Version number.
 	 */
-	public function __construct( $file = '', $version = '3.9.1' ) {
+	public function __construct( $file = '', $version = '3.9.2' ) {
 		$this->_version = $version;
 		$this->_token   = 'cuws';
 
@@ -235,7 +235,7 @@ class CUWS {
 
 		// hide "Go Premium" metabox on edit Post/Page screens
 		if ( ! empty( $this->options['hide_premium_metabox'] ) ) {
-			echo '.wpseo-metabox-buy-premium,.AnalysisUpsell__Container-dJCCGN,.wpseo-metabox-root>div:last-child>div:last-child{display:none!important;}'; // @since v3.6.0 hide "Go Premium" metabox on Edit Post/Page screens
+			echo '.wpseo-metabox-buy-premium{display:none!important;}'; // @since v3.6.0 hide "Go Premium" metabox on Edit Post/Page screens
 		}
 
 		// hide Post/Page/Taxonomy Deletion Premium Ad
@@ -363,7 +363,7 @@ class CUWS {
 	 *
 	 * @return CUWS $_instance
 	 */
-	public static function instance( $file = '', $version = '3.9.1' ) {
+	public static function instance( $file = '', $version = '3.9.2' ) {
 		if ( null === self::$_instance ) {
 			self::$_instance = new self( $file, $version );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: hide, seo, bloat, remove, ads, cartoon, wordpress seo addon, admin columns
 Requires at least: 4.7.2
 Requires PHP: 5.6
 Tested up to: 5.0
-Stable tag: 3.9.1
+Stable tag: 3.9.2
 License: GPL-3.0+
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -39,7 +39,7 @@ The **Default Settings** of the current release are as follows:
 * hides image warning nag that shows in edit Post/Page screen when featured image is smaller than 200x200 pixels
 * hides check Configuration wizard box that shows on top of most admin screens
 * hides issue counter from adminbar and sidebar
-* **NEW:** hides new readability "features" of Post/Page metabox
+* hides new readability "features" of Post/Page metabox
 * hides ad for premium version in help center
 * hides the SEO Score, Readability, Title and Meta Description admin columns on the Posts/Pages screens; Focus keyword column can be hidden too
 * hides the SEO Score and Readability admin columns on taxonomies
@@ -96,10 +96,15 @@ Please open an issue on [Github](https://github.com/senlin/so-clean-up-wp-seo/is
 
 == Changelog ==
 
+= 3.9.2 =
+
+* release date November 19, 2018
+* fix issue where Go Premium metabox option makes snippet preview box blank (https://wordpress.org/support/topic/go-premium-metabox-option-makes-snippet-preview-box-blank/); thanks for reporting @pxlar8
+
 = 3.9.1 =
 
 * release date October 29, 2018
-* fix hiding "Add related keyphrase" in metabox as it only serves as an add for premium version
+* fix hiding "Add related keyphrase" in metabox as it only serves as an ad for premium version
 
 = 3.9.0 =
 

--- a/so-clean-up-wp-seo.php
+++ b/so-clean-up-wp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: 		Hide SEO Bloat
  * Plugin URI:  		https://so-wp.com/plugin/hide-seo-bloat
  * Description:			Hide most of the bloat that the Yoast SEO plugin adds to your WordPress Dashboard
- * Version:     		3.9.1
+ * Version:     		3.9.2
  * Author:				SO WP
  * Author URI:  		https://so-wp.com
  * License:    			GPL-3.0+
@@ -31,7 +31,7 @@ require_once( 'admin/class-so-clean-up-wp-seo-admin-api.php' );
  * @return object CUWS
  */
 function CUWS () {
-	$instance = CUWS::instance( __FILE__, '3.9.1' );
+	$instance = CUWS::instance( __FILE__, '3.9.2' );
 
 	if ( null === $instance->settings ) {
 		$instance->settings = CUWS_Settings::instance( $instance );


### PR DESCRIPTION
* release date November 19, 2018
* fix issue where Go Premium metabox option makes snippet preview box blank (https://wordpress.org/support/topic/go-premium-metabox-option-makes-snippet-preview-box-blank/); thanks for reporting @pxlar8