### PR TITLE
commit v3.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Hide SEO Bloat
 
-[![plugin version](https://img.shields.io/wordpress/plugin/v/so-clean-up-wp-seo.svg)](https://wordpress.org/plugins/so-clean-up-wp-seo)
+[![plugin version](https://img.shields.io/wordpress/plugin/v/so-clean-up-wp-seo.svg)](https://wordpress.org/plugins/so-clean-up-wp-seo) [![WP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/wp-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest) [![PHP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/php-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest) [![ClassicPress tested on version 1.0.1](https://img.shields.io/badge/ClassicPress-1.0.1-03768e.svg?style=flat-round)](https://www.classicpress.net)
 
-###### Last updated on June 17, 2019
-###### Development version 3.11.0
+###### Last updated on July 27, 2019
+###### Development version 3.11.1
 ###### requires at least WordPress 4.7.2
-###### tested up to WordPress 5.2.1
+###### tested up to WordPress 5.2.2
 ###### tested up to ClassicPress 1.0.1
 ###### Author: [Pieter Bos](https://github.com/senlin)
 ###### Contributor: [Andy Fragen](https://github.com/afragen)
@@ -18,7 +18,7 @@ Almost anyone who uses the Yoast SEO plugin will agree that it is a good SEO plu
 
 **New in this version:**
 
-* remove HTML comments that show in source code (frontend)
+* hide ad that promotes premium local seo services 
 
 The purpose of the Hide SEO Bloat plugin, a free addon for the Yoast SEO plugin, is to clean up all those unwanted things.
 
@@ -57,7 +57,7 @@ The default settings of the current release are as follows:
 * removes Courses menu from sidebar
 * hides SEO Scores Dropdown Filters on the Edit Posts/Pages screen
 * hides Keyword/Content Score from the Publish/Update Metabox on the Edit Post/Page/CPT screen
-* remove HTML comments that show in source code (frontend)
+* remove HTML comments that show in source code (frontend) upgraded for use with version 11 and above of Yoast SEO
 
 ## Frequently Asked Questions
 
@@ -119,9 +119,15 @@ We welcome your contributions very much! PR's will be considered and of course b
 
 ## Changelog
 
+### 3.11.1
+
+* release date July 27, 2019
+* refactor remove HTML comments from source code (frontend) with thanks to [Robert Went](https://www.robertwent.com/blog/remove-yoast-html-comments-in-version-11-0/)
+* hide upsell ad for local seo; addresses [issue #57](https://github.com/senlin/so-clean-up-wp-seo/issues/57) 
+
 ### 3.11.0
 
-* release date April 27, 2019
+* release date June 17, 2019
 * remove HTML comments from source code (frontend)
 
 ### 3.10.1

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -99,7 +99,7 @@ class CUWS {
 	 * @param string $file
 	 * @param string $version Version number.
 	 */
-	public function __construct( $file = '', $version = '3.11.0' ) {
+	public function __construct( $file = '', $version = '3.11.1' ) {
 		$this->_version = $version;
 		$this->_token   = 'cuws';
 
@@ -128,7 +128,7 @@ class CUWS {
 		// @since 3.10.0
 		add_action( 'admin_menu', array( $this, 'so_cuws_remove_menu_item'), 999 );
 		// @since 3.11.0
-		add_action( 'template_redirect', array( $this, 'so_cuws_remove_frontend_html_comments' ), 9999 );
+		add_action( 'plugins_loaded', array( $this, 'so_cuws_remove_frontend_html_comments' ), 999 );
 
 		// Load API for generic admin functions
 		if ( is_admin() ) {
@@ -208,14 +208,21 @@ class CUWS {
 
 	/**
 	 * Upon request by many the plugin now also removes the frontend HTML comments left by Yoast
+	 * improvements of v3.11.1 via [Robert Went](https://gist.github.com/robwent/f36e97fdd648a40775379a86bd97b332)
 	 *
 	 * @since v3.11.0
+	 * @modified v3.11.1
 	 */
 	public function so_cuws_remove_frontend_html_comments() {
 
 		if ( ! empty( $this->options['remove_html_comments'] ) ) {
 
-			remove_action( 'wpseo_head', array( WPSEO_Frontend::get_instance(), 'debug_mark' ), 2 );
+			if ( defined( 'WPSEO_VERSION' ) ) {
+				add_action( 'get_header', function () { ob_start( function ( $o ) {
+					return preg_replace( '/\n?<.*?Yoast SEO plugin.*?>/mi', '', $o ); } ); } );
+				add_action('wp_head',function (){ ob_end_flush(); }, 999);
+			}
+
 		}
     }
 
@@ -257,7 +264,7 @@ class CUWS {
 
 		// hide premium upsell admin block
 		if ( ! empty( $this->options['hide_upsell_admin_block'] ) ) {
-			echo '.yoast_premium_upsell_admin_block{display:none}'; // @since v3.1.0
+			echo '.yoast_premium_upsell_admin_block,#wpseo-local-seo-upsell{display:none}'; // @since v3.1.0; @modified v3.11.1
 		}
 
 		// hide "Premium" submenu in its entirety
@@ -411,7 +418,7 @@ class CUWS {
 	 *
 	 * @return CUWS $_instance
 	 */
-	public static function instance( $file = '', $version = '3.11.0' ) {
+	public static function instance( $file = '', $version = '3.11.1' ) {
 		if ( null === self::$_instance ) {
 			self::$_instance = new self( $file, $version );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://so-wp.com/donations
 Tags: hide, seo, bloat, remove, ads, cartoon, wordpress seo addon, admin columns, nags, traffic light, dashboard widget, hide premium
 Requires at least: 4.7.2
 Requires PHP: 5.6
-Tested up to: 5.2.1
-Stable tag: 3.11.0
+Tested up to: 5.2.2
+Stable tag: 3.11.1
 License: GPL-3.0+
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -17,7 +17,7 @@ Almost anyone who uses the Yoast SEO plugin will agree that it is a good SEO plu
 
 **New in this version:**
 
-* remove HTML comments that show in source code (frontend)
+* hide ad that promotes premium local seo services
 
 The purpose of the Hide SEO Bloat plugin, a free addon for the Yoast SEO plugin, is to clean up all those unwanted things.
 
@@ -52,8 +52,7 @@ The **Default Settings** of the current release are as follows:
 * removes Courses menu from sidebar
 * hides SEO Scores Dropdown Filters on the Edit Posts/Pages screen
 * hides Keyword/Content Score from the Publish/Update Metabox on the Edit Post/Page/CPT screen
-* remove HTML comments that show in source code (frontend)
-
+* remove HTML comments that show in source code (frontend) upgraded for use with version 11 and above of Yoast SEO
 
 We support this plugin exclusively through [Github](https://github.com/senlin/so-clean-up-wp-seo/issues). Therefore, if you have any questions, need help and/or want to make a feature request, please open an issue over at Github. You can also browse through open and closed issues to find what you are looking for and perhaps even help others.
 
@@ -103,9 +102,15 @@ Please open an issue on [Github](https://github.com/senlin/so-clean-up-wp-seo/is
 
 == Changelog ==
 
+= 3.11.1 =
+
+* release date July 27, 2019
+* refactor remove HTML comments from source code (frontend) with thanks to [Robert Went](https://www.robertwent.com/blog/remove-yoast-html-comments-in-version-11-0/)
+* hide upsell ad for local seo; addresses [issue #57](https://github.com/senlin/so-clean-up-wp-seo/issues/57)
+
 = 3.11.0 =
 
-* release date April 27, 2019
+* release date June 17, 2019
 * remove HTML comments from source code (frontend)
 
 = 3.10.1 =

--- a/so-clean-up-wp-seo.php
+++ b/so-clean-up-wp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: 		Hide SEO Bloat
  * Plugin URI:  		https://so-wp.com/plugin/hide-seo-bloat
  * Description:			Hide most of the bloat that the Yoast SEO plugin adds to your WordPress Dashboard
- * Version:     		3.11.0
+ * Version:     		3.11.1
  * Author:				SO WP
  * Author URI:  		https://so-wp.com
  * License:    			GPL-3.0+
@@ -31,7 +31,7 @@ require_once( 'admin/class-so-clean-up-wp-seo-admin-api.php' );
  * @return object CUWS
  */
 function CUWS () {
-	$instance = CUWS::instance( __FILE__, '3.11.0' );
+	$instance = CUWS::instance( __FILE__, '3.11.1' );
 
 	if ( null === $instance->settings ) {
 		$instance->settings = CUWS_Settings::instance( $instance );


### PR DESCRIPTION
* release date July 27, 2019
* refactor remove HTML comments from source code (frontend) with thanks to [Robert Went](https://www.robertwent.com/blog/remove-yoast-html-comments-in-version-11-0/)
* hide upsell ad for local seo; addresses [issue #57](https://github.com/senlin/so-clean-up-wp-seo/issues/57)