### PR TITLE
merge v3.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Hide SEO Bloat
 
-[![plugin version](https://img.shields.io/wordpress/plugin/v/so-clean-up-wp-seo)](https://wordpress.org/plugins/so-clean-up-wp-seo) [![WP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/wp-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest) [![PHP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/php-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest) [![ClassicPress tested on version 1.2.0](https://img.shields.io/badge/ClassicPress-1.2.0-03768e?style=flat-round)](https://www.classicpress.net)
+[![plugin version](https://img.shields.io/wordpress/plugin/v/so-clean-up-wp-seo)](https://wordpress.org/plugins/so-clean-up-wp-seo) [![WP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/wp-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest) [![PHP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/php-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest)
 
-###### Last updated on May 20, 2020
-###### Development version 3.14.0
+###### Last updated on August 1, 2020
+###### Development version 3.14.1
 ###### requires at least WordPress 4.7.2
-###### tested up to WordPress 5.4
-###### tested up to ClassicPress 1.2.0
+###### tested up to WordPress 5.5
 ###### Author: [Pieter Bos](https://github.com/senlin)
 ###### Contributor: [Andy Fragen](https://github.com/afragen)
 
@@ -18,7 +17,7 @@ Almost anyone who uses the Yoast SEO plugin will agree that it is a good SEO plu
 
 **New in this version:**
 
-* hide new notice that shows after deleting content (post, page, product, other CPT)
+* hide premium upsell ad from social tab of Yoast SEO Metabox (thanks @allanrehhoff)
 
 <hr>
 
@@ -122,6 +121,12 @@ We welcome your contributions very much! PR's will be considered and of course b
 
 
 ## Changelog
+
+### 3.14.1
+
+* release date August 1, 2020
+* hide premium upsell ad from social tab of Yoast SEO Metabox (thanks @allanrehhoff)
+* tested up to WP 5.5
 
 ### 3.14.0
 

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -99,7 +99,7 @@ class CUWS {
 	 * @param string $file
 	 * @param string $version Version number.
 	 */
-	public function __construct( $file = '', $version = '3.14.0' ) {
+	public function __construct( $file = '', $version = '3.14.1' ) {
 		$this->_version = $version;
 		$this->_token   = 'cuws';
 
@@ -536,7 +536,7 @@ class CUWS {
 	 *
 	 * @return CUWS $_instance
 	 */
-	public static function instance( $file = '', $version = '3.14.0' ) {
+	public static function instance( $file = '', $version = '3.14.1' ) {
 		if ( null === self::$_instance ) {
 			self::$_instance = new self( $file, $version );
 		}

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -393,7 +393,7 @@ class CUWS {
 
 		// hide premium upsell admin block
 		if ( ! empty( $this->options['hide_upsell_admin_block'] ) ) {
-			echo '.yoast_premium_upsell,.yoast_premium_upsell_admin_block,#wpseo-local-seo-upsell{display:none}'; // @since v3.1.0; @modified v3.11.1; @modified v3.13.2
+			echo '.yoast_premium_upsell,.yoast_premium_upsell_admin_block,#wpseo-local-seo-upsell,div[class^="SocialUpsell__PremiumInfoText"]{display:none}'; // @since v3.1.0; @modified v3.11.1; @modified v3.13.2; @modified v3.14.1
 		}
 
 		// hide "Premium" submenu in its entirety

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://so-wp.com/donations
 Tags: hide, seo, bloat, remove, ads, cartoon, wordpress seo addon, admin columns, nags, dashboard widget, hide premium, classicpress
 Requires at least: 4.7.2
 Requires PHP: 5.6
-Tested up to: 5.4
-Stable tag: 3.14.0
+Tested up to: 5.5
+Stable tag: 3.14.1
 License: GPL-3.0+
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -17,7 +17,7 @@ Almost anyone who uses the Yoast SEO plugin will agree that it is a good SEO plu
 
 **New in this version:**
 
-* hide new notice that shows after deleting content (post, page, product, other CPT)
+* hide premium upsell ad from social tab of Yoast SEO Metabox (thanks @allanrehhoff)
 
 <hr>
 
@@ -110,6 +110,12 @@ Please open an issue on [Github](https://github.com/senlin/so-clean-up-wp-seo/is
 5. dashboard widget that is removed with the plugin activated
 
 == Changelog ==
+
+= 3.14.1 =
+
+* release date August 1, 2020
+* hide premium upsell ad from social tab of Yoast SEO Metabox (thanks @allanrehhoff)
+* tested up to WP 5.5
 
 = 3.14.0 =
 

--- a/so-clean-up-wp-seo.php
+++ b/so-clean-up-wp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: 		Hide SEO Bloat
  * Plugin URI:  		https://so-wp.com/plugin/hide-seo-bloat
  * Description:			Hide most of the bloat that the Yoast SEO plugin adds to your WordPress Dashboard
- * Version:     		3.14.0
+ * Version:     		3.14.1
  * Author:				SO WP
  * Author URI:  		https://so-wp.com
  * License:    			GPL-3.0+
@@ -34,7 +34,7 @@ require_once( 'admin/class-so-clean-up-wp-seo-admin-api.php' );
  * @return object CUWS
  */
 function CUWS () {
-	$instance = CUWS::instance( __FILE__, '3.14.0' );
+	$instance = CUWS::instance( __FILE__, '3.14.1' );
 
 	if ( null === $instance->settings ) {
 		$instance->settings = CUWS_Settings::instance( $instance );


### PR DESCRIPTION
* release date August 1, 2020
* hide premium upsell ad from social tab of Yoast SEO Metabox (thanks @allanrehhoff)
* tested up to WP 5.5