### PR TITLE
commit v3.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![plugin version](https://img.shields.io/wordpress/plugin/v/so-clean-up-wp-seo)](https://wordpress.org/plugins/so-clean-up-wp-seo) [![WP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/wp-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest) [![PHP compatibility](https://plugintests.com/plugins/so-clean-up-wp-seo/php-badge.svg)](https://plugintests.com/plugins/so-clean-up-wp-seo/latest)
 
 ###### Last updated on August 1, 2020
-###### Development version 3.14.1
+###### Development version 3.14.2
 ###### requires at least WordPress 4.7.2
 ###### tested up to WordPress 5.5
 ###### Author: [Pieter Bos](https://github.com/senlin)
@@ -121,6 +121,11 @@ We welcome your contributions very much! PR's will be considered and of course b
 
 
 ## Changelog
+
+### 3.14.2
+
+* release date August 1, 2020
+* improved hiding notice (added to v3.14.0) that shows after content deletion as it also shows after deleting taxonomies (thanks @KoolPal)
 
 ### 3.14.1
 

--- a/includes/class-so-clean-up-wp-seo.php
+++ b/includes/class-so-clean-up-wp-seo.php
@@ -99,7 +99,7 @@ class CUWS {
 	 * @param string $file
 	 * @param string $version Version number.
 	 */
-	public function __construct( $file = '', $version = '3.14.1' ) {
+	public function __construct( $file = '', $version = '3.14.2' ) {
 		$this->_version = $version;
 		$this->_token   = 'cuws';
 
@@ -489,12 +489,20 @@ class CUWS {
 
 		// hide content/keyword score on Publish/Update Post metabox
 		if ( ! empty( $this->options['hide_content_keyword_score'] ) ) {
-			echo '#misc-publishing-actions #content-score, #misc-publishing-actions #keyword-score{display:none;}'; // @since v3.10.0 hide "Content / Keyword Score" from  Publish/Update metabox
+			echo '
+				#misc-publishing-actions #content-score,
+				#misc-publishing-actions #keyword-score
+				{display:none;}
+			'; // @since v3.10.0 hide "Content / Keyword Score" from  Publish/Update metabox
 		}
 
 		// hide Premium ad after deleting content (post, page, wc product, cpt)
 		if ( ! empty( $this->options['hide_ad_after_trashing_content'] ) ) {
-			echo 'body.edit-php .yoast-notification.notice.notice-warning.is-dismissible{display:none;}'; // @since v3.14.0
+			echo '
+				body.edit-php .yoast-notification.notice.notice-warning.is-dismissible,
+				body[class*="taxonomy-"] .yoast-notification.notice.notice-warning.is-dismissible
+				{display:none;}
+			'; // @since v3.14.0; @modified v3.14.2
 		}
 
 		echo '</style>';
@@ -536,7 +544,7 @@ class CUWS {
 	 *
 	 * @return CUWS $_instance
 	 */
-	public static function instance( $file = '', $version = '3.14.1' ) {
+	public static function instance( $file = '', $version = '3.14.2' ) {
 		if ( null === self::$_instance ) {
 			self::$_instance = new self( $file, $version );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,11 @@ Please open an issue on [Github](https://github.com/senlin/so-clean-up-wp-seo/is
 
 == Changelog ==
 
+= 3.14.2 =
+
+* release date August 1, 2020
+* improved hiding notice (added to v3.14.0) that shows after content deletion as it also shows after deleting taxonomies (thanks @KoolPal)
+
 = 3.14.1 =
 
 * release date August 1, 2020

--- a/so-clean-up-wp-seo.php
+++ b/so-clean-up-wp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: 		Hide SEO Bloat
  * Plugin URI:  		https://so-wp.com/plugin/hide-seo-bloat
  * Description:			Hide most of the bloat that the Yoast SEO plugin adds to your WordPress Dashboard
- * Version:     		3.14.1
+ * Version:     		3.14.2
  * Author:				SO WP
  * Author URI:  		https://so-wp.com
  * License:    			GPL-3.0+
@@ -34,7 +34,7 @@ require_once( 'admin/class-so-clean-up-wp-seo-admin-api.php' );
  * @return object CUWS
  */
 function CUWS () {
-	$instance = CUWS::instance( __FILE__, '3.14.1' );
+	$instance = CUWS::instance( __FILE__, '3.14.2' );
 
 	if ( null === $instance->settings ) {
 		$instance->settings = CUWS_Settings::instance( $instance );


### PR DESCRIPTION
* release date August 1, 2020
* improved hiding notice (added to v3.14.0) that shows after content deletion as it also shows after deleting taxonomies (thanks @KoolPal)